### PR TITLE
Download and package (or disable) CSS as part of docset

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -74,6 +74,11 @@ $(INFO_PLIST_FILE): src/Info.plist $(CONTENTS_DIR)
 $(INDEX_FILE): src/index-pages.sh $(DOCUMENTS_DIR)
 	rm -f $@
 	src/index-pages.sh $@ $(DOCUMENTS_DIR)/*.html
+ifndef NO_CSS
+	src/set-stylesheet.sh "yes" $(DOCUMENTS_DIR)/*.html
+else
+	src/set-stylesheet.sh "no" $(DOCUMENTS_DIR)/*.html
+endif
 	src/index-terms.sh "Entry" $@ $(DOCUMENTS_DIR)/Concept-Index.html
 	src/index-terms.sh "Directive" $@ $(DOCUMENTS_DIR)/Name-Index.html
 

--- a/README
+++ b/README
@@ -8,10 +8,13 @@ To generate a docset from the latest edition of the GNU Make Manual, simply
 execute `make` from the same directory as this README file. The latest edition
 will be downloaded from www.gnu.org and packaged appropriately.
 
+If you would prefer a docset without CSS, this can be specified by running `make NO_CSS=yes`.
+Otherwise, a local CSS file will also be downloaded from www.gnu.org and included in the docset.
+
 Requirements:
 
 - any POSIX-compliant shell
 - curl    - https://curl.se/
 - make    - https://www.gnu.org/software/make/
-- pup     - https://tracker.debian.org/pkg/pup
+- pup     - https://github.com/ericchiang/pup
 - sqlite3 - https://www.sqlite.org/index.html

--- a/src/set-stylesheet.sh
+++ b/src/set-stylesheet.sh
@@ -1,0 +1,44 @@
+#!/usr/bin/sh
+
+unset LOCAL_CSS_PATH
+unset WEB_CSS_PATH
+CSS="$1"
+shift
+
+get_css_path() {
+	# Used to set WEB_CSS_PATH
+	pup "link[rel=stylesheet] attr{href}" -f "$1"
+}
+
+stylesheet_replace() {
+	# Replace each stylesheet href value with LOCAL_CSS_PATH
+	while [ -n "$1" ]; do
+		sed -i 's|'"$(pup link[rel=stylesheet] -f "$1")"'|<link rel="stylesheet" type="text/css" href="manual.css">|g' "$1"
+		shift
+	done
+}
+
+stylesheet_remove() {
+	# Remove the stylesheet link
+	while [ -n "$1" ]; do
+		sed -i 's|'"$(pup link[rel=stylesheet] -f "$1")"'||g' "$1"
+		shift
+	done
+}
+
+if [ "$CSS" = "yes" ]; then
+	WEB_CSS_PATH="$(get_css_path "$1")"
+	if [ -n "$WEB_CSS_PATH" ]; then
+		LOCAL_CSS_PATH="$(dirname "$1")"/manual.css
+		curl -o "$LOCAL_CSS_PATH" "$WEB_CSS_PATH"
+	fi
+	if [ -r "$LOCAL_CSS_PATH" ]; then
+		stylesheet_replace "$@"
+	else
+		CSS="no"
+	fi
+fi
+
+if [ "$CSS" = "no" ]; then
+	stylesheet_remove "$@"
+fi


### PR DESCRIPTION
The script will now download the CSS file referenced by the stylesheet link in the head of each page and replace this link's `<href>` with a reference to the local CSS file.

`make` can also be called with `NO_CSS` defined, which will remove the stylesheet link in each page and not download the CSS, as referenced in the README